### PR TITLE
feat: add storing q_field and searchText for better UX

### DIFF
--- a/src/common/api/search/index.ts
+++ b/src/common/api/search/index.ts
@@ -16,6 +16,7 @@ class SearchApi {
   }
 
   static async getSearchKeywords(tab: string): Promise<ISearchKeywords> {
+    // 추천/인기/최근검색어 탭을 의미함
     const response = await apiCall.get(
       `${ApiUrl.base}${ApiUrl.search}/?tab=${tab}`
     );

--- a/src/common/hooks/useLocalStorage.ts
+++ b/src/common/hooks/useLocalStorage.ts
@@ -1,6 +1,8 @@
+import { ISearchQuery } from "../store/searchInput";
+
 export interface ILocalStorage {
   name?: LocalStorageName | "";
-  value?: string;
+  value?: ISearchQuery[] | string;
 }
 
 export enum LocalStorageName {
@@ -17,7 +19,7 @@ export function emptyLocalStorage(name: LocalStorageName) {
 
 // get, set, delete localStorage
 export function setLocalStorage({ name = "", value = "" }: ILocalStorage) {
-  window.localStorage.setItem(name, value);
+  window.localStorage.setItem(name, JSON.stringify(value));
 }
 
 export function getLocalStorage(name: LocalStorageName) {

--- a/src/common/store/searchInput.ts
+++ b/src/common/store/searchInput.ts
@@ -1,0 +1,27 @@
+import { atom, selector } from "recoil";
+
+export interface ISearchQuery {
+  q_field: string;
+  searchText: string;
+}
+
+export const searchQuery = atom<ISearchQuery>({
+  // 쿼리필드와 검색필드 2개 관리
+  key: "search-query",
+  default: {
+    q_field: "whole",
+    searchText: "",
+  },
+});
+
+export const getSearchQuerySelector = selector({
+  // 검색어 쿼리 실시간 업데이트용 셀렉터. 미완
+  key: "search-query/get",
+  get: ({ get }) => {
+    const data = get(searchQuery);
+    return data;
+  },
+  set: ({ set }, newValue) => {
+    set(searchQuery, newValue);
+  },
+});

--- a/src/common/types/search.ts
+++ b/src/common/types/search.ts
@@ -1,3 +1,5 @@
+import { ISearchQuery } from "../store/searchInput";
+
 export interface ISearchResult {
   id: number;
   name: string;
@@ -14,5 +16,5 @@ export interface ISearchResult {
 }
 
 export interface ISearchKeywords {
-  keywords: string[];
+  keywords: ISearchQuery[];
 }

--- a/src/components/common/searchBar/SearchBar.tsx
+++ b/src/components/common/searchBar/SearchBar.tsx
@@ -8,6 +8,8 @@ import CategoryDropdown, { categoryList, IOption } from "./categoryDropdown";
 import SearchModal from "./searchModal";
 import { SearchModalCategories } from "./searchModal/CategoryTab";
 import useRecentSearch from "./useRecentSearch";
+import { getSearchQuerySelector } from "@src/common/store/searchInput";
+import { useRecoilState } from "recoil";
 
 export interface ISearchPayload {
   category: string;
@@ -21,8 +23,12 @@ const SearchBar = () => {
     handleComponentVisible,
   } = useComponentVisible(); // 검색바 온오프 영역설정 커스텀 훅
   const { updateRecentSearch } = useRecentSearch(); // 최근검색어 훅에서 최근검색어 업데이트 함수 가져오기
-  const [searchInput, setSearchInput] = useState<string>(""); // 검색어 쿼리 상태값
-  const [category, setCategory] = useState<IOption>(categoryList[0]); // 통합검색/제품명/브랜드/키워드 확인 상태값
+  const [searchParam, setSearchParam] = useRecoilState(getSearchQuerySelector); // 검색어 쿼리 실시간 연동용 atom. 기능 구현 미완
+  const [searchInput, setSearchInput] = useState(searchParam.searchText); // 검색어 쿼리 상태값
+  const [category, setCategory] = useState<IOption>(
+    categoryList.find((ele) => ele.value == searchParam.q_field) ||
+      categoryList[0] // recoil atom값이랑 일치하는 최신 값 동기화
+  ); // 통합검색/제품명/브랜드/키워드 확인 상태값
   const [recentUpdate, setRecentUpdate] = useState<number>(0); // 업데이트 여부 확인용 상태값
   const [currentTab, setCurrentTab] = useState<IOption>(
     SearchModalCategories[2]
@@ -34,7 +40,14 @@ const SearchBar = () => {
       alert("검색어를 입력해주세요.");
       return;
     }
-    updateRecentSearch({ value: searchInput }); // 최근검색어 업데이트
+    setSearchParam({
+      q_field: category.value,
+      searchText: searchInput,
+    }); // searchQuery atom에 업데이트
+    updateRecentSearch({
+      q_field: category.value,
+      searchText: searchInput,
+    }); // 최근검색어 업데이트
     setRecentUpdate(recentUpdate + 1); // 검색창 최신화
     router.push({
       // next router훅 사용해 검색결과페이지로 넘어감

--- a/src/components/common/searchBar/searchModal/KeywordList.tsx
+++ b/src/components/common/searchBar/searchModal/KeywordList.tsx
@@ -3,9 +3,10 @@ import KeywordItem from "./KeywordItem";
 import { ISearchModal } from ".";
 import styled from "@emotion/styled";
 import { palette } from "@src/styles/styles";
+import { ISearchQuery } from "@src/common/store/searchInput";
 
 interface IKeywordList extends ISearchModal {
-  searchKeywords: string[];
+  searchKeywords: ISearchQuery[]; // 검색어 데이터는 ISearchQuery 배열 형태임
 }
 
 const KeywordList = ({
@@ -19,8 +20,8 @@ const KeywordList = ({
       {searchKeywords && searchKeywords.length > 0 ? (
         searchKeywords.map((keyword) => (
           <KeywordItem
-            key={keyword}
-            text={keyword}
+            key={JSON.stringify(Object.values(keyword))}
+            query={keyword}
             currentTab={currentTab}
             recentUpdate={recentUpdate}
             setRecentUpdate={setRecentUpdate}

--- a/src/components/common/searchBar/searchModal/index.tsx
+++ b/src/components/common/searchBar/searchModal/index.tsx
@@ -28,10 +28,11 @@ const SearchModal = ({
   setCurrentTab,
 }: ISearchModal) => {
   const { deleteRecentSearchAll } = useRecentSearch();
-  const { searchKeywords } = useSearchKeywordQuery(currentTab); // 추천/인기/최근 검색어
-  const recentSearchKeywords: string[] = emptyLocalStorage(
-    LocalStorageName.RecentSearchList
-  );
+  const { searchKeywords } = useSearchKeywordQuery(currentTab); // 추천/인기 검색어 데이터
+  const recentSearchKeywords =
+    emptyLocalStorage(LocalStorageName.RecentSearchList).length > 0
+      ? JSON.parse(emptyLocalStorage(LocalStorageName.RecentSearchList))
+      : emptyLocalStorage(LocalStorageName.RecentSearchList);
 
   const handleDeleteRecentSearchAll = () => {
     deleteRecentSearchAll();

--- a/src/components/common/searchBar/searchModal/index.tsx
+++ b/src/components/common/searchBar/searchModal/index.tsx
@@ -28,14 +28,14 @@ const SearchModal = ({
   setCurrentTab,
 }: ISearchModal) => {
   const { deleteRecentSearchAll } = useRecentSearch();
-  const { searchKeywords } = useSearchKeywordQuery(currentTab);
+  const { searchKeywords } = useSearchKeywordQuery(currentTab); // 추천/인기/최근 검색어
   const recentSearchKeywords: string[] = emptyLocalStorage(
     LocalStorageName.RecentSearchList
   );
 
   const handleDeleteRecentSearchAll = () => {
     deleteRecentSearchAll();
-    // 최근 검색어 바꼈으니까 recentUpdate + 1
+    // 최근 검색어 리스트가 바꼈으니까 recentUpdate + 1
     setRecentUpdate(recentUpdate + 1);
   };
 

--- a/src/components/common/searchBar/useRecentSearch.ts
+++ b/src/components/common/searchBar/useRecentSearch.ts
@@ -1,19 +1,22 @@
+import { ISearchQuery } from "@src/common/store/searchInput";
 import {
   deleteLocalStorage,
   emptyLocalStorage,
-  getLocalStorage,
-  ILocalStorage,
   LocalStorageName,
   setLocalStorage,
 } from "@src/common/hooks/useLocalStorage";
 
 const useRecentSearch = () => {
   // 최근검색어 업데이트
-  const updateRecentSearch = ({ value }: ILocalStorage) => {
+  const updateRecentSearch = (value: ISearchQuery) => {
     // localStorage에서 가져오고 validation check
-    let recentSearchList = emptyLocalStorage(LocalStorageName.RecentSearchList);
-    // recentSearchList에 value가 이미 있는지 check
-    const already = recentSearchList.indexOf(value);
+    const isEmpty = emptyLocalStorage(LocalStorageName.RecentSearchList);
+    // emptyLocalStorage()로 가져오는 값은 문자열화돼있는 배열이거나 빈 배열임
+    let recentSearchList = isEmpty.length > 0 ? JSON.parse(isEmpty) : isEmpty;
+    // recentSearchList에 value가 이미 있는지 check. 빈 배열이거나 객체로 채워져있는 배열 모두 비교 가능
+    const already = recentSearchList.findIndex(
+      (ele: ISearchQuery) => JSON.stringify(ele) == JSON.stringify(value)
+    );
     // recentSearchList에 value가 이미 있으면
     if (already >= 0) {
       // 기존에 있던 검색어 삭제하고
@@ -35,11 +38,12 @@ const useRecentSearch = () => {
   };
 
   // 최근검색어 하나 삭제
-  const deleteRecentSearchEach = ({ value }: ILocalStorage) => {
-    const recentSearchList = JSON.parse(
-      getLocalStorage(LocalStorageName.RecentSearchList) || ""
+  const deleteRecentSearchEach = (value: ISearchQuery) => {
+    const isEmpty = emptyLocalStorage(LocalStorageName.RecentSearchList);
+    const recentSearchList = isEmpty.length > 0 ? JSON.parse(isEmpty) : isEmpty;
+    const already = recentSearchList.findIndex(
+      (ele: ISearchQuery) => JSON.stringify(ele) == JSON.stringify(value)
     );
-    const already = recentSearchList.indexOf(value);
     if (already >= 0) {
       recentSearchList.splice(already, 1);
     }

--- a/src/components/common/searchBar/useSearch.ts
+++ b/src/components/common/searchBar/useSearch.ts
@@ -36,6 +36,7 @@ export const useSearchQuery = () => {
 };
 
 export const useSearchKeywordQuery = (currentTab: IOption) => {
+  // 추천/인기/최근검색어 api calling function
   const { data } = useQuery<ISearchKeywords>(
     ["search-keywords", currentTab.value],
     () => SearchApi.getSearchKeywords(currentTab.value),

--- a/src/components/search-result/SearchResultList/index.tsx
+++ b/src/components/search-result/SearchResultList/index.tsx
@@ -9,7 +9,6 @@ const SearchResultList = ({
 }: {
   searchResult: ISearchResult;
 }) => {
-  console.log(searchResult);
   return (
     <ListWrapper>
       {Object(searchResult).length > 0 ? (

--- a/src/pages/search-result/index.tsx
+++ b/src/pages/search-result/index.tsx
@@ -14,7 +14,6 @@ export interface ICurrentCategory {
 const SearchResultPage = () => {
   const { searchResult } = useSearchQuery();
   const [currentCate, setCurrentCate] = useState<string>("향수");
-  console.log(searchResult);
 
   return (
     <CenterWrapper>


### PR DESCRIPTION
노션에 공유드린 검색어 쿼리 개선사항입니다.
https://www.notion.so/connie-keum/api-2b6d444ba01645f7ad9d9ca199b5a176

현재 실행 가능한 기능:
- 검색어 q_field와 searchText 쌍으로 저장 및 display
- 검색어 블록 클릭 시 검색 및 해당 블록의 검색어와 쿼리필드 검색 input에 반영
- 검색 input창과 검색 카테고리 수동으로 기입 후 검색 시에도 해당 값들 유지

아직 보완해야할 점:
- 검색결과 페이지에서 메인페이지로 뒤로가기 시 input창 초기화
- 검색결과 페이지에서 검색바 모달에 있는 검색어 블록 클릭으로 검색 시 검색 input창 동기화 안됨(리코일 atom 저장되는 시간 > next SPA 업데이트 시간?)