### PR TITLE
feat: Main Page Magazine 활성화

### DIFF
--- a/src/common/api/product/index.ts
+++ b/src/common/api/product/index.ts
@@ -35,7 +35,7 @@ class ProductApi {
 
   static async getProductReview(id: string): Promise<IProductReviewResponse[]> {
     const response = await apiCall.get(
-      `${ApiUrl.base}${ApiUrl.product.detail}${parseInt(id)}/review/`
+      `${ApiUrl.base}${ApiUrl.product.detail}/${parseInt(id)}/review/`
     );
 
     if (response.status !== 200) {

--- a/src/components/home/magazine/MagazineItem.tsx
+++ b/src/components/home/magazine/MagazineItem.tsx
@@ -5,14 +5,16 @@ import React from "react";
 import Link from "next/link";
 
 interface IMagazineItem {
-  text: string;
+  content: string;
+  query: string;
 }
 
-const MagazineItem = ({ text }: IMagazineItem) => {
+const MagazineItem = (mag: IMagazineItem) => {
+  console.log(mag);
   return (
-    <Link href={`magazine/${text}`} key={text}>
+    <Link href={`magazine/tags/${mag.query}`} key={mag.query}>
       <MagazineItemSection>
-        <span>{text}</span>
+        <span>{mag.content}</span>
       </MagazineItemSection>
     </Link>
   );

--- a/src/components/home/magazine/MagazineItem.tsx
+++ b/src/components/home/magazine/MagazineItem.tsx
@@ -10,7 +10,6 @@ interface IMagazineItem {
 }
 
 const MagazineItem = (mag: IMagazineItem) => {
-  console.log(mag);
   return (
     <Link href={`magazine/tags/${mag.query}`} key={mag.query}>
       <MagazineItemSection>

--- a/src/components/home/magazine/MagazineItem.tsx
+++ b/src/components/home/magazine/MagazineItem.tsx
@@ -2,6 +2,7 @@ import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
 import { palette } from "@src/styles/styles";
 import React from "react";
+import Link from "next/link";
 
 interface IMagazineItem {
   text: string;
@@ -9,9 +10,11 @@ interface IMagazineItem {
 
 const MagazineItem = ({ text }: IMagazineItem) => {
   return (
-    <MagazineItemSection>
-      <span>{text}</span>
-    </MagazineItemSection>
+    <Link href={`magazine/${text}`} key={text}>
+      <MagazineItemSection>
+        <span>{text}</span>
+      </MagazineItemSection>
+    </Link>
   );
 };
 

--- a/src/components/home/magazine/index.tsx
+++ b/src/components/home/magazine/index.tsx
@@ -9,18 +9,18 @@ import { VStack, HStack } from "@common-components";
 
 // text가 12개씩 들어온다 가정
 const text = [
-  "여름밤의 촉촉한 향 BEST 10",
-  "달콤한 플로럴 향 BEST 20",
-  "남자 우디 향수 BEST 10",
-  "포근한 파우더 향 BEST 30",
-  "상쾌한 시트러스 향 BEST 20 ",
-  "호불호 없는 여자 향수 BEST 10",
-  "가나다라 BEST 10",
-  "마바사 BEST 20",
-  "아자차카 BEST 10",
-  "타파하 BEST 30",
-  "1234 BEST 20 ",
-  "5678 BEST 10",
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "남자 우디 향수 BEST 10", query: "cool" },
+  { content: "포근한 파우더 향 BEST 30", query: "cool" },
+  { content: "상쾌한 시트러스 향 BEST 20 ", query: "cool" },
+  { content: "호불호 없는 여자 향수 BEST 10", query: "cool" },
+  { content: "달콤한 플로럴 향 BEST 20", query: "sweet" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
+  { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
 ];
 
 const Magazine = () => {
@@ -52,7 +52,7 @@ const Magazine = () => {
           {text
             .slice(offset(nowPage), offset(nowPage) + limit)
             .map((t, index) => (
-              <MagazineItem key={index} text={t} />
+              <MagazineItem key={index} content={t.content} query={t.query} />
             ))}
         </BoxSection>
 

--- a/src/components/home/magazine/index.tsx
+++ b/src/components/home/magazine/index.tsx
@@ -10,7 +10,7 @@ import { VStack, HStack } from "@common-components";
 // text가 12개씩 들어온다 가정
 const text = [
   { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
-  { content: "남자 우디 향수 BEST 10", query: "cool" },
+  { content: "남자 우디 향수 BEST 10", query: "clean" },
   { content: "포근한 파우더 향 BEST 30", query: "cool" },
   { content: "상쾌한 시트러스 향 BEST 20 ", query: "cool" },
   { content: "호불호 없는 여자 향수 BEST 10", query: "cool" },

--- a/src/components/home/magazine/index.tsx
+++ b/src/components/home/magazine/index.tsx
@@ -11,9 +11,9 @@ import { VStack, HStack } from "@common-components";
 const text = [
   { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
   { content: "남자 우디 향수 BEST 10", query: "clean" },
-  { content: "포근한 파우더 향 BEST 30", query: "cool" },
-  { content: "상쾌한 시트러스 향 BEST 20 ", query: "cool" },
-  { content: "호불호 없는 여자 향수 BEST 10", query: "cool" },
+  { content: "포근한 파우더 향 BEST 30", query: "calm" },
+  { content: "상쾌한 시트러스 향 BEST 20 ", query: "refreshing" },
+  { content: "호불호 없는 여자 향수 BEST 10", query: "romantic" },
   { content: "달콤한 플로럴 향 BEST 20", query: "sweet" },
   { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },
   { content: "여름밤의 촉촉한 향 BEST 10", query: "cool" },

--- a/src/components/magazine/useMagazineBox.tsx
+++ b/src/components/magazine/useMagazineBox.tsx
@@ -28,7 +28,12 @@ const MagazineBox = ({
         <Producer>{producer}</Producer>
       </InfoSection>
       <ProfileImg src="/assets/images/blank-profile.png" />
-      <Content>{productReview[0]?.content}</Content>
+      {productReview[0]?.content.length === 0 && (
+        <Content>너무 좋은 향이에요 !!</Content>
+      )}
+      {productReview[0]?.content.length > 0 && (
+        <Content>{productReview[0]?.content}</Content>
+      )}
       <InfoSection>
         <ToDetail>
           <Link href={`${RouterUrl.ProductDetail}/${id}`}>


### PR DESCRIPTION
메인 페이지에 있던 매거진 섹션을 매거진 페이지와 연결시켰습니다.
아직 tags 값이 clean, sweet, cool 밖에 없지만 노가다를 통해 가져올 수 있는 api를 계속 추가해 볼 예정입니다.



https://user-images.githubusercontent.com/86956991/211580786-244d91f5-4c2c-42d1-906a-07ee7a8e6806.mov


